### PR TITLE
bug: favorites was not showing the favorite draws

### DIFF
--- a/app/(dashboard)/_components/search-input.tsx
+++ b/app/(dashboard)/_components/search-input.tsx
@@ -2,13 +2,14 @@
 
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import qs from "query-string";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
 
 export const SearchInput = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const [value, setValue] = useState("");
   const [debouncedValue] = useDebounceValue(value, 500);
@@ -23,13 +24,14 @@ export const SearchInput = () => {
         url: "/",
         query: {
           search: debouncedValue,
+          favorites: searchParams.get("favorites"),
         },
       },
       { skipEmptyString: true, skipNull: true }
     );
 
     router.push(url);
-  }, [debouncedValue, router]);
+  }, [debouncedValue, router, searchParams]);
 
   return (
     <div className="w-full relative">

--- a/convex/draws.ts
+++ b/convex/draws.ts
@@ -26,7 +26,14 @@ export const get = query({
 
       const draws = await getAllOrThrow(ctx.db, ids);
 
-      return draws.map((draw) => ({ ...draw, isFavorite: true }));
+      const title = args.search as string;
+      const filteredDraws = title
+        ? draws.filter((draw) =>
+            draw.title.toLowerCase().includes(title.toLowerCase())
+          )
+        : draws;
+
+      return filteredDraws.map((draw) => ({ ...draw, isFavorite: true }));
     }
 
     const title = args.search as string;


### PR DESCRIPTION
The Issue was in searchinput component:

When you clicked on "Favorite Draws" and then used the search box, the search functionality was removing the [favorites=true] parameter from the URL. This caused the page to show all draws instead of only the favorited ones.